### PR TITLE
Update URL to match CNAME

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title: Refactoring Words
 email: hi@refactoringwords.com
 description: Learn to write well using your refactoring skills.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://localhost:4000" # the base hostname & protocol for your site, e.g. http://example.com
+url: "http://refactoringwords.com" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jnraine
 github_username:  jnraine
 

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ title: Refactoring Words
 email: hi@refactoringwords.com
 description: Learn to write well using your refactoring skills.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://refactoringwords.com" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://refactoringwords.com" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jnraine
 github_username:  jnraine
 


### PR DESCRIPTION
While navigating your site I noticed that clicking the home button goes to `localhost:4000`.

## How to reproduce the bug
https://user-images.githubusercontent.com/11095731/114601854-fae5ed80-9c63-11eb-9bdd-23fe173e9a06.mov


## Summary of change
This PR proposes that you update `localhost:4000` to be `refactoringwords.com`, so that when someone clicks the home button, they are taken to the correct URL.




